### PR TITLE
Makefile: don't install the binary as man page.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -56,7 +56,7 @@ ifeq "$(wildcard .git doc/hungrycat.1)" ".git"
 	# run "$(MAKE) -C doc" to build the manpage
 else
 	install -d $(DESTDIR)$(mandir)/man1/
-	install -m644 $(<) $(DESTDIR)$(mandir)/man1/hungrycat.1
+	install -m644 doc/$(<).1 $(DESTDIR)$(mandir)/man1/hungrycat.1
 endif
 
 hungrycat: hungrycat.o


### PR DESCRIPTION
`$ make install` currently installs the `hungrycat` binary twice. Once in `bin/`, and once as...
```
$ man 1 hungrycat
^?ELF^B^A^A^@^@^@^@^@^@^@^@^@^B^@>^@^A^@^@^@<A0>^M@^@^@^@^@^@@^@^@^@^@^@^@^@<C8>
-^@^@^@^@^@^@^@^@^@^@@^@8^@     ^@@^@^]^@^\^@^F^@^@^@^E^@^@^@@^@^@^@^@^@^@^@@^@@
[...]
```
Here's a very simple fix (in the spirit of the current Makefile).
I didn't add a changelog entry; that's probably better left to the maintainer.

Thanks!
:smiley_cat: :cake: